### PR TITLE
Made "runInForeground" chainable

### DIFF
--- a/src/GO/Job/Job.php
+++ b/src/GO/Job/Job.php
@@ -387,6 +387,8 @@ abstract class Job implements LoggerAwareInterface
   public function runInForeground()
   {
     $this->runInBackground = false;
+    
+    return $this;
   }
 
   /**

--- a/tests/GO/Job/JobTest.php
+++ b/tests/GO/Job/JobTest.php
@@ -56,6 +56,13 @@ class JobTest extends \PHPUnit_Framework_TestCase
     $this->assertFalse($job->runInBackground);
   }
 
+  public function testRunInForgroundIsChainable()
+  {
+    $job = JobFactory::factory('GO\Job\Php', 'some command')->runInForeground()->at('* * * * *');
+
+    $this->assertFalse($job->runInBackground);
+  }
+
   public function testShouldAppendArgs()
   {
     $args = [


### PR DESCRIPTION
The docs show runInForeground being chained with the following function being "every", however this fails as it does not return the instance of the Job class being used. added "return $this" to method