### PR TITLE
Optional verbose lock files and doNotOverlap support for closures

### DIFF
--- a/src/GO/Job/Job.php
+++ b/src/GO/Job/Job.php
@@ -280,7 +280,7 @@ abstract class Job implements LoggerAwareInterface
    */
   public function isDue()
   {
-    return $this->execution->isDue() && $this->truthTest === true;
+    return $this->execution->isDue(date("c", $this->time)) && $this->truthTest === true;
   }
 
   /**

--- a/src/GO/Job/Job.php
+++ b/src/GO/Job/Job.php
@@ -346,6 +346,18 @@ abstract class Job implements LoggerAwareInterface
   }
 
   /**
+   * Remove lock file after closure execution.
+   *
+   * @return void
+   */
+  protected function removeLock()
+  {
+    if (file_exists($this->lockFile)) {
+      unlink($this->lockFile);
+    }
+  }
+  
+  /**
    * Execute the job
    *
    * @return string - The output of the executed job
@@ -364,6 +376,9 @@ abstract class Job implements LoggerAwareInterface
       if (is_string($return)) {
         $jobOutput[] = $return;
       }
+      
+      // unlink lock file
+      $this->removeLock();
     } else {
       $return = exec($this->compiled, $jobOutput);
     }

--- a/src/GO/Job/Job.php
+++ b/src/GO/Job/Job.php
@@ -27,6 +27,13 @@ abstract class Job implements LoggerAwareInterface
    */
   protected $args;
 
+    /**
+     * Optional identifier for the command to determine concurrency instead of the command itself.
+     *
+     * @var null|string
+     */
+  protected $commandId;
+
   /**
    * The compiled command
    *
@@ -119,15 +126,18 @@ abstract class Job implements LoggerAwareInterface
    *
    * @param mixed $job
    * @param array $args
+   * @param string $commandId
    * @return void
    */
-  public function __construct($job, array $args = [])
+  public function __construct($job, array $args = [], $commandId = null)
   {
     $this->time = time();
 
     $this->command = $job;
 
     $this->args = $args;
+
+    $this->commandId = $commandId;
 
     if (method_exists($this, 'init')) {
       $this->init();
@@ -142,6 +152,18 @@ abstract class Job implements LoggerAwareInterface
   public function getCommand()
   {
     return $this->command;
+  }
+
+    /**
+     * Get commandId
+     *
+     * @return array|string
+     */
+  public function getCommandId()
+  {
+      if(isset($this->commandId) && is_string($this->commandId) && !empty($this->commandId))
+          return $this->commandId;
+      return $this->getCommand();
   }
 
   /**

--- a/src/GO/Job/JobFactory.php
+++ b/src/GO/Job/JobFactory.php
@@ -15,14 +15,15 @@ class JobFactory
    * @param string $class
    * @param string $command
    * @param array $args
+   * @param string $commandId
    * @return instance of GO\Job\Job
    */
-  public static function factory($class, $command, array $args = [])
+  public static function factory($class, $command, array $args = [], $commandId = null)
   {
     if (!class_exists($class)) {
       throw new InvalidFactoryException("Class $class doesn't exists");
     }
 
-    return new $class($command, $args);
+    return new $class($command, $args, $commandId);
   }
 }

--- a/src/GO/Scheduler.php
+++ b/src/GO/Scheduler.php
@@ -228,7 +228,7 @@ class Scheduler
 
           // Create lock file for this job to prevent overlap
           $lockFile = implode('/', [$this->getTempDir(), md5($job->getCommand()) . '.lock']);
-          Filesystem::write('', $lockFile);
+          Filesystem::write($job->getCommand(), $lockFile);
           // Sets the file to remove after the execution
           $job->removeLockAfterExec($lockFile);
           // Sets the job to run in foreground

--- a/src/GO/Scheduler.php
+++ b/src/GO/Scheduler.php
@@ -228,7 +228,10 @@ class Scheduler
 
           // Create lock file for this job to prevent overlap
           $lockFile = implode('/', [$this->getTempDir(), md5($job->getCommand()) . '.lock']);
-          Filesystem::write($job->getCommand(), $lockFile);
+          $lockFileContent = '';
+          if(isset($this->config['verboseLockFile']) && $this->config['verboseLockFile'] == true)
+              $lockFileContent = $job->getCommand();
+          Filesystem::write($lockFileContent, $lockFile);
           // Sets the file to remove after the execution
           $job->removeLockAfterExec($lockFile);
           // Sets the job to run in foreground

--- a/src/GO/Scheduler.php
+++ b/src/GO/Scheduler.php
@@ -251,7 +251,7 @@ class Scheduler
    * If overlapping and a callback has been provided,
    * the result of that function will decide if the job can overlap.
    *
-   * @param GO\Job\Job $job
+   * @param \GO\Job\Job $job
    * @return bool
    */
   private function jobCanRun(\GO\Job\Job $job)

--- a/tests/GO/SchedulerTest.php
+++ b/tests/GO/SchedulerTest.php
@@ -144,6 +144,8 @@ class SchedulerTest extends \PHPUnit_Framework_TestCase
     $scheduler->run();
 
     $this->assertEquals(0, count($scheduler->getExecutedJobs()));
+
+    unlink($path);
   }
 
   public function testVerboseLockFileShouldWriteCommandToLockFile()
@@ -158,11 +160,21 @@ class SchedulerTest extends \PHPUnit_Framework_TestCase
 
       $scheduler->call(function() use ($commandId, $path){
               $lockFileContent = trim(file_get_contents($path));
-              $this->assertEquals($commandId.'2', $lockFileContent);
+              $this->assertEquals($commandId, $lockFileContent);
           }, [], $commandId)
           ->at('* * * * *')
           ->doNotOverlap();
 
-      $scheduler->run();
+      try
+      {
+          $scheduler->run();
+      }
+      catch(\PHPUnit_Framework_AssertionFailedError $e){
+          throw $e;
+      }
+      finally
+      {
+          unlink($path);
+      }
   }
 }

--- a/tests/GO/SchedulerTest.php
+++ b/tests/GO/SchedulerTest.php
@@ -145,4 +145,24 @@ class SchedulerTest extends \PHPUnit_Framework_TestCase
 
     $this->assertEquals(0, count($scheduler->getExecutedJobs()));
   }
+
+  public function testVerboseLockFileShouldWriteCommandToLockFile()
+  {
+      $scheduler = new Scheduler([
+          'tempDir' => __DIR__ . '/../tmp',
+          'verboseLockFile' => true
+      ]);
+
+      $commandId = 'FooBar';
+      $path = implode('/', [$scheduler->getTempDir(), md5($commandId) . '.lock']);
+
+      $scheduler->call(function() use ($commandId, $path){
+              $lockFileContent = trim(file_get_contents($path));
+              $this->assertEquals($commandId.'2', $lockFileContent);
+          }, [], $commandId)
+          ->at('* * * * *')
+          ->doNotOverlap();
+
+      $scheduler->run();
+  }
 }

--- a/tests/GO/SchedulerTest.php
+++ b/tests/GO/SchedulerTest.php
@@ -172,9 +172,5 @@ class SchedulerTest extends \PHPUnit_Framework_TestCase
       catch(\PHPUnit_Framework_AssertionFailedError $e){
           throw $e;
       }
-      finally
-      {
-          unlink($path);
-      }
   }
 }


### PR DESCRIPTION
Hi,
thanks for your project! I had to do some alterations to make it suit my needs. But everything is fully down compatible. So I'd love to see the changes pulled back into your package.

Changes:
Now you can use doNotOverlap() on Jobs, that where created by calling Scheduler::call() with an anonymous function as parameter. In that case your scheduler throws an exception right now. The only thing you need to add, is an `commandId` as a third parameter to call(). Added $args support to call() btw.

`$scheduler->call(function(){
              return 'Hello World';
          }, [], 'Hello World Command')
          ->at('* * * * *')
          ->doNotOverlap();`

Another new feature is the possibility, to write the commands or commandIds to lock files. This way investigation of abandoned lock files becomes much easier in environments, heavily utilizing php-cron-scheduler
Works like this:
`$scheduler = new Scheduler([
          'tempDir' => __DIR__ . '/../tmp',
          'verboseLockFile' => true
      ]);`