### PR TITLE
 Allow run() to be executed multiple times 

### DIFF
--- a/src/GO/Scheduler.php
+++ b/src/GO/Scheduler.php
@@ -275,8 +275,7 @@ class Scheduler
     }
 
     /**
-     * Remove all queued Jobs
-     *
+     * Remove all queued Jobs.
      */
     public function clearJobs()
     {

--- a/src/GO/Scheduler.php
+++ b/src/GO/Scheduler.php
@@ -153,11 +153,6 @@ class Scheduler
      */
     public function run()
     {
-        // Reset collected data of last run
-        $this->executedJobs = [];
-        $this->failedJobs = [];
-        $this->outputSchedule = [];
-
         $jobs = $this->getQueuedJobs();
 
         foreach ($jobs as $job) {
@@ -172,6 +167,19 @@ class Scheduler
         }
 
         return $this->getExecutedJobs();
+    }
+
+    /**
+     * Reset all collected data of last run.
+     *
+     * Call before run() if you call run() multiple times.
+     */
+    public function resetRun()
+    {
+        // Reset collected data of last run
+        $this->executedJobs = [];
+        $this->failedJobs = [];
+        $this->outputSchedule = [];
     }
 
     /**

--- a/src/GO/Scheduler.php
+++ b/src/GO/Scheduler.php
@@ -153,6 +153,11 @@ class Scheduler
      */
     public function run()
     {
+        // Reset collected data of last run
+        $this->executedJobs = [];
+        $this->failedJobs = [];
+        $this->outputSchedule = [];
+
         $jobs = $this->getQueuedJobs();
 
         foreach ($jobs as $job) {

--- a/src/GO/Scheduler.php
+++ b/src/GO/Scheduler.php
@@ -273,4 +273,13 @@ class Scheduler
                 throw new InvalidArgumentException('Invalid output type');
         }
     }
+
+    /**
+     * Remove all queued Jobs
+     *
+     */
+    public function clearJobs()
+    {
+        $this->jobs = [];
+    }
 }

--- a/src/GO/Scheduler.php
+++ b/src/GO/Scheduler.php
@@ -155,8 +155,10 @@ class Scheduler
     {
         $jobs = $this->getQueuedJobs();
 
+        $runTime = new DateTime('now');
+
         foreach ($jobs as $job) {
-            if ($job->isDue()) {
+            if ($job->isDue($runTime)) {
                 try {
                     $job->run();
                     $this->pushExecutedJob($job);

--- a/tests/GO/SchedulerTest.php
+++ b/tests/GO/SchedulerTest.php
@@ -253,7 +253,6 @@ class SchedulerTest extends TestCase
         $this->assertEquals('async_foreground', $jobs[1]->getId());
     }
 
-
     public function testCouldRunTwice()
     {
         $scheduler = new Scheduler();

--- a/tests/GO/SchedulerTest.php
+++ b/tests/GO/SchedulerTest.php
@@ -269,4 +269,19 @@ class SchedulerTest extends TestCase
 
         $this->assertCount(1, $scheduler->getExecutedJobs(), 'Number of executed jobs');
     }
+
+    public function testClearJobs()
+    {
+        $scheduler = new Scheduler();
+
+        $scheduler->call(function () {
+            return true;
+        });
+
+        $this->assertCount(1, $scheduler->getQueuedJobs(), 'Number of queued jobs');
+
+        $scheduler->clearJobs();
+
+        $this->assertCount(0, $scheduler->getQueuedJobs(), 'Number of queued jobs');
+    }
 }

--- a/tests/GO/SchedulerTest.php
+++ b/tests/GO/SchedulerTest.php
@@ -252,4 +252,21 @@ class SchedulerTest extends TestCase
         $this->assertEquals('async_background', $jobs[0]->getId());
         $this->assertEquals('async_foreground', $jobs[1]->getId());
     }
+
+    public function testCouldRunTwice()
+    {
+        $scheduler = new Scheduler();
+
+        $scheduler->call(function () {
+            return true;
+        });
+
+        $scheduler->run();
+
+        $this->assertCount(1, $scheduler->getExecutedJobs(), 'Number of executed jobs');
+
+        $scheduler->run();
+
+        $this->assertCount(1, $scheduler->getExecutedJobs(), 'Number of executed jobs');
+    }
 }

--- a/tests/GO/SchedulerTest.php
+++ b/tests/GO/SchedulerTest.php
@@ -265,6 +265,7 @@ class SchedulerTest extends TestCase
 
         $this->assertCount(1, $scheduler->getExecutedJobs(), 'Number of executed jobs');
 
+        $scheduler->resetRun();
         $scheduler->run();
 
         $this->assertCount(1, $scheduler->getExecutedJobs(), 'Number of executed jobs');


### PR DESCRIPTION
The current code expects the run() to be called only once. This is
fine if you start the scheduler from cron each minute and re-initialize
it each time. If you want to manually run the scheduler, or maybe
have a lot of jobs you do not want to init each minute, it would
be useful to call run() multiple times in the lifetime of the
scheduler.

In this case the collected data of the last run should be reset.
the executedJobs, failedJobs and outputSchedule.

If the scheduler is used to do multiple runs then it would be useful
to reset all queued Jobs. Currently the only way to do this is by
re-creating the scheduler object. But if the object is injected in the
code then this is not practical.