### PR TITLE
Allow run() to run at arbitrary time

### DIFF
--- a/src/GO/Scheduler.php
+++ b/src/GO/Scheduler.php
@@ -149,13 +149,16 @@ class Scheduler
     /**
      * Run the scheduler.
      *
+     * @param DateTime $runTime  Optional, run at specific moment
      * @return array  Executed jobs
      */
-    public function run()
+    public function run($runTime = null)
     {
         $jobs = $this->getQueuedJobs();
 
-        $runTime = new DateTime('now');
+        if (is_null($runTime)) {
+            $runTime = new DateTime('now');
+        }
 
         foreach ($jobs as $job) {
             if ($job->isDue($runTime)) {

--- a/tests/GO/SchedulerTest.php
+++ b/tests/GO/SchedulerTest.php
@@ -1,5 +1,6 @@
 <?php namespace GO\Job\Tests;
 
+use DateTime;
 use GO\Scheduler;
 use PHPUnit\Framework\TestCase;
 
@@ -303,5 +304,19 @@ class SchedulerTest extends TestCase
         $executed = $scheduler->run();
 
         $this->assertEquals(2, count($executed));
+    }
+
+    public function testShouldRunAtSpecificTime()
+    {
+        $scheduler = new Scheduler();
+        $runTime = new DateTime('2017-09-13 00:00:00');
+
+        $scheduler->call(function () {
+            // do nothing
+        })->daily('00:00');
+
+        $executed = $scheduler->run($runTime);
+
+        $this->assertEquals(1, count($executed));
     }
 }


### PR DESCRIPTION
Currently when run() is called it uses the current time as the run
timestamp. However it would be useful to run the scheduler at a
specific time. So allow an optional param with a DateTime to run().

Reasons for running at a specific time other than now() could be:

- Catching up on 'missed' runs, eg. when the system was down.

- Making sure the scheduler runs at an intended timestamp eg. when
cron is started at midnight it could be slow and start the php process
only at 00:01 and thus missing all midnight schedules.

- Improve testability of the scheduler (fake the time)