### PR TITLE
Fixed mail transport when not specified in scheduler constructor

### DIFF
--- a/src/GO/Traits/Mailer.php
+++ b/src/GO/Traits/Mailer.php
@@ -42,9 +42,9 @@ trait Mailer
      */
     private function sendToEmails(array $files)
     {
-        $mailer = new \Swift_Mailer($this->emailConfig['transport']);
-
         $config = $this->getEmailConfig();
+
+        $mailer = new \Swift_Mailer($config['transport']);
 
         $message = (new \Swift_Message())
             ->setSubject($config['subject'])


### PR DESCRIPTION
Mails will fail if no transport is defined on scheduler constructor.

The `getEmailConfig` will default the transport to Sendmail.