### PR TITLE
Fixes #94 by checking for an array parameter when creating a Job ID

### DIFF
--- a/src/GO/Job.php
+++ b/src/GO/Job.php
@@ -157,6 +157,8 @@ class Job
         } else {
             if (is_string($command)) {
                 $this->id = md5($command);
+            } elseif (is_array($command)){
+                $this->id = md5(serialize($command));
             } else {
                 /* @var object $command */
                 $this->id = spl_object_hash($command);

--- a/tests/GO/JobTest.php
+++ b/tests/GO/JobTest.php
@@ -14,6 +14,9 @@ class JobTest extends TestCase
             return true;
         });
         $this->assertTrue(is_string($job2->getId()));
+
+        $job3 = new Job(['MyClass', 'myMethod']);
+        $this->assertTrue(is_string($job3->getId()));
     }
 
     public function testShouldGenerateIdFromSignature()
@@ -23,6 +26,9 @@ class JobTest extends TestCase
 
         $job2 = new Job('whoami');
         $this->assertNotEquals($job1->getId(), $job2->getId());
+
+        $job3 = new Job(['MyClass', 'myMethod']);
+        $this->assertNotEquals($job1->getId(), $job3->getId());
     }
 
     public function testShouldAllowCustomId()
@@ -31,6 +37,9 @@ class JobTest extends TestCase
 
         $this->assertNotEquals(md5('ls'), $job->getId());
         $this->assertEquals('aCustomId', $job->getId());
+
+        $job2 = new Job(['MyClass', 'myMethod'], null, 'myCustomId');
+        $this->assertEquals('myCustomId', $job2->getId());
     }
 
     public function testShouldKnowIfDue()


### PR DESCRIPTION
The constructor for the Job class now specifically checks for arrays passed as command parameters (a valid "callable" structure) and creates an ID based on the MD5 version of the serialized array.