### PR TITLE
added the option to capture stderr into the output file

### DIFF
--- a/src/GO/Job.php
+++ b/src/GO/Job.php
@@ -144,6 +144,11 @@ class Job
     private $outputMode;
 
     /**
+     * @var bool
+     */
+    private $captureStdErr = false;
+
+    /**
      * Create a new Job instance.
      *
      * @param  string|callable  $command
@@ -301,6 +306,10 @@ class Job
 
         // Add the boilerplate to redirect the output to file/s
         if (count($this->outputTo) > 0) {
+            if ($this->captureStdErr) {
+                $compiled .= ' 2>&1';
+            }
+
             $compiled .= ' | tee ';
             $compiled .= $this->outputMode === 'a' ? '-a ' : '';
             foreach ($this->outputTo as $file) {
@@ -473,6 +482,19 @@ class Job
     {
         $this->outputTo = is_array($filename) ? $filename : [$filename];
         $this->outputMode = $append === false ? 'w' : 'a';
+
+        return $this;
+    }
+
+    /**
+     * Set the option for writing stderr to the output file
+     *
+     * @param bool $capture
+     * @return self
+     */
+    public function captureStandardError($capture = true)
+    {
+        $this->captureStdErr = $capture;
 
         return $this;
     }

--- a/tests/GO/JobOutputFilesTest.php
+++ b/tests/GO/JobOutputFilesTest.php
@@ -198,4 +198,47 @@ class JobOutputFilesTest extends TestCase
 
         unlink($outputFile);
     }
+
+    public function testShouldWriteStdErrToFile()
+    {
+        $command = PHP_BINARY . ' ' . __DIR__ . '/../error_job.php';
+        $job = new Job($command);
+        $outputFile = __DIR__ . '/../tmp/output.log';
+
+        @unlink($outputFile);
+
+        // Test fist that the file doesn't exist yet
+        $this->assertFalse(file_exists($outputFile));
+        $job->captureStandardError();
+        $job->output($outputFile)->run();
+
+        sleep(2);
+        $this->assertTrue(file_exists($outputFile));
+
+        // Content should be the error for calling an undefined function
+        $this->assertStringStartsWith('PHP Fatal error:', file_get_contents($outputFile));
+
+        unlink($outputFile);
+    }
+
+    public function testShouldNotWriteStdErrToFile()
+    {
+        $command = PHP_BINARY . ' ' . __DIR__ . '/../error_job.php';
+        $job = new Job($command);
+        $outputFile = __DIR__ . '/../tmp/output.log';
+
+        @unlink($outputFile);
+
+        // Test fist that the file doesn't exist yet
+        $this->assertFalse(file_exists($outputFile));
+        $job->output($outputFile)->run();
+
+        sleep(2);
+        $this->assertTrue(file_exists($outputFile));
+
+        // Content should be ''
+        $this->assertEquals('', file_get_contents($outputFile));
+
+        unlink($outputFile);
+    }
 }

--- a/tests/error_job.php
+++ b/tests/error_job.php
@@ -1,0 +1,3 @@
+<?php
+
+call_a_function_that_does_not_exist();


### PR DESCRIPTION
I had an issue where a syntax error in a cron script was causing a silent failure.

I have added the option to track stderr into the output file (if any) on a per job basis. By default stderr will be ignored to maintain comparability with the existing lib