### PR TITLE
Laravel 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^7.1",
-        "dragonmantank/cron-expression": "^2.3"
+        "dragonmantank/cron-expression": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.7",


### PR DESCRIPTION
Laravel 8 requires dragonmantank/cron-expression v3.
So upgrading to Laravel 8 is not possible without this change.