### PR TITLE
Added php 8.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: php
 php:
-  - '7.1'
-  - '7.2'
+  - '7.3'
+  - '7.4'
+  - '8.0'
   - hhvm
 
 matrix:
@@ -16,7 +17,7 @@ install:
   - php composer.phar install --no-interaction
 
 script:
-  - php vendor/bin/phpunit -c phpunit.xml
+  - XDEBUG_MODE=coverage php vendor/bin/phpunit -c phpunit.xml --coverage-clover clover.xml
 
 after_success:
-  - travis_retry php vendor/bin/coveralls -v
+  - travis_retry php vendor/bin/php-coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": "^7.1",
+        "php": "^7.3 || ^8.0",
         "dragonmantank/cron-expression": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7",
-        "satooshi/php-coveralls": "^1.0",
+        "phpunit/phpunit": "~9.5",
+        "php-coveralls/php-coveralls": "^2.4",
         "swiftmailer/swiftmailer": "~5.4 || ^6.0"
     },
     "suggest": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,28 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="./vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
-    <testsuites>
-        <testsuite name="Scheduler Test Suite">
-            <directory>./tests/</directory>
-        </testsuite>
-    </testsuites>
-    <php>
-        <env name="APP_ENV" value="testing"/>
-    </php>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory>src/GO</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-clover" target="clover.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="./vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory>src/GO</directory>
+    </include>
+    <report>
+      <clover outputFile="clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Scheduler Test Suite">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+  </php>
+  <logging/>
 </phpunit>

--- a/tests/GO/IntervalTest.php
+++ b/tests/GO/IntervalTest.php
@@ -32,11 +32,10 @@ class IntervalTest extends TestCase
         $this->assertTrue($job->hourly(19)->isDue(\DateTime::createFromFormat('H:i', '11:19')));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testShouldThrowExceptionWithInvalidHourlyMinuteInput()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $job = new Job('ls');
         $job->hourly('abc');
     }
@@ -63,20 +62,18 @@ class IntervalTest extends TestCase
         $this->assertTrue($job->daily('19:53')->isDue(\DateTime::createFromFormat('H:i', '19:53')));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testShouldThrowExceptionWithInvalidDailyHourInput()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $job = new Job('ls');
         $job->daily('abc');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testShouldThrowExceptionWithInvalidDailyMinuteInput()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $job = new Job('ls');
         $job->daily(2, 'abc');
     }

--- a/tests/GO/JobTest.php
+++ b/tests/GO/JobTest.php
@@ -141,11 +141,10 @@ class JobTest extends TestCase
         $this->assertInstanceOf(Job::class, $job->email(['test@mail.com', 'other@mail.com']));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testShouldFailIfEmailInputIsNotStringOrArray()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $job = new Job('ls');
 
         $job->email(1);
@@ -159,11 +158,10 @@ class JobTest extends TestCase
         ]));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testShouldFailIfEmailConfigurationIsNotArray()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $job = new Job('ls');
         $job->configure([
             'email' => 123,

--- a/tests/GO/SchedulerTest.php
+++ b/tests/GO/SchedulerTest.php
@@ -62,11 +62,10 @@ class SchedulerTest extends TestCase
         $this->assertEquals(PHP_BINARY . ' ' . $script, $job->compile());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testShouldThrowExceptionIfScriptIsNotAString()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $scheduler = new Scheduler();
         $scheduler->php(function () {
             return false;
@@ -234,8 +233,8 @@ class SchedulerTest extends TestCase
 
         $scheduler->run();
 
-        $this->assertRegexp('/ Executing Closure$/', $scheduler->getVerboseOutput());
-        $this->assertRegexp('/ Executing Closure$/', $scheduler->getVerboseOutput('text'));
+        $this->assertMatchesRegularExpression('/ Executing Closure$/', $scheduler->getVerboseOutput());
+        $this->assertMatchesRegularExpression('/ Executing Closure$/', $scheduler->getVerboseOutput('text'));
     }
 
     public function testShouldShowClosuresVerboseOutputAsHtml()
@@ -254,7 +253,7 @@ class SchedulerTest extends TestCase
 
         $scheduler->run();
 
-        $this->assertRegexp('/<br>/', $scheduler->getVerboseOutput('html'));
+        $this->assertMatchesRegularExpression('/<br>/', $scheduler->getVerboseOutput('html'));
     }
 
     public function testShouldShowClosuresVerboseOutputAsArray()
@@ -277,11 +276,10 @@ class SchedulerTest extends TestCase
         $this->assertEquals(count($scheduler->getVerboseOutput('array')), 2);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testShouldThrowExceptionWithInvalidOutputType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $scheduler = new Scheduler();
 
         $scheduler->call(function ($phrase) {


### PR DESCRIPTION
Closes #116 

1. Add support of PHP 8.0 in `composer.json`
2. Upgrade phpunit from 5.7 to 9.5 (because 5.7 doesn't support php 8.0)
3. Remove support of php 7.1 and 7.2 unsupported by new version of phpunit
4. Migrate phpunit config to new configuration format
5. Upgrade exception expectation system to new phpunit 9 definition
6. Replace deprecated `satooshi/php-coveralls` by suggested replacement.