### PR TITLE
Fixing Scheduler on Windows w/ Spaces in PHP_BINARY Path

### DIFF
--- a/src/GO/Scheduler.php
+++ b/src/GO/Scheduler.php
@@ -126,6 +126,10 @@ class Scheduler
         $bin = $bin !== null && is_string($bin) && file_exists($bin) ?
             $bin : (PHP_BINARY === '' ? '/usr/bin/php' : PHP_BINARY);
 
+				if (PHP_OS_FAMILY == 'Windows' && stripos($bin, ' ') !== false) {
+					$bin = '"{$bin}"';
+				}
+
         $job = new Job($bin . ' ' . $script, $args, $id);
 
         if (! file_exists($script)) {

--- a/src/GO/Scheduler.php
+++ b/src/GO/Scheduler.php
@@ -126,9 +126,9 @@ class Scheduler
         $bin = $bin !== null && is_string($bin) && file_exists($bin) ?
             $bin : (PHP_BINARY === '' ? '/usr/bin/php' : PHP_BINARY);
 
-				if (PHP_OS_FAMILY == 'Windows' && stripos($bin, ' ') !== false) {
-					$bin = '"{$bin}"';
-				}
+        if (PHP_OS_FAMILY == 'Windows' && stripos($bin, ' ') !== false) {
+            $bin = '"{$bin}"';
+        }
 
         $job = new Job($bin . ' ' . $script, $args, $id);
 


### PR DESCRIPTION
Adding some code to catch if running on Windows and the PHP_BINARY path includes spaces.  Adds double quotes around the value of `$bin` so it can run without issues.

Tested as working on Windows 10 with PHP 7.4 and 8.0.