### PR TITLE
Switched from using \Exception to using \Throwable

### DIFF
--- a/src/GO/FailedJob.php
+++ b/src/GO/FailedJob.php
@@ -1,6 +1,6 @@
 <?php namespace GO;
 
-use Exception;
+use Throwable;
 
 class FailedJob
 {
@@ -10,11 +10,11 @@ class FailedJob
     private $job;
 
     /**
-     * @var Exception
+     * @var Throwable
      */
     private $exception;
 
-    public function __construct(Job $job, Exception $exception)
+    public function __construct(Job $job, Throwable $exception)
     {
         $this->job = $job;
         $this->exception = $exception;
@@ -25,7 +25,7 @@ class FailedJob
         return $this->job;
     }
 
-    public function getException(): Exception
+    public function getException(): Throwable
     {
         return $this->exception;
     }

--- a/src/GO/Job.php
+++ b/src/GO/Job.php
@@ -1,8 +1,8 @@
 <?php namespace GO;
 
 use DateTime;
-use Exception;
 use InvalidArgumentException;
+use Throwable;
 
 class Job
 {
@@ -433,7 +433,7 @@ class Job
      * Execute a callable job.
      *
      * @param  callable  $fn
-     * @throws Exception
+     * @throws Throwable
      * @return string
      */
     private function exec(callable $fn)
@@ -442,7 +442,7 @@ class Job
 
         try {
             $returnData = call_user_func_array($fn, $this->args);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             ob_end_clean();
             throw $e;
         }

--- a/src/GO/Scheduler.php
+++ b/src/GO/Scheduler.php
@@ -1,7 +1,7 @@
 <?php namespace GO;
 
 use DateTime;
-use Exception;
+use Throwable;
 use InvalidArgumentException;
 
 class Scheduler
@@ -176,7 +176,7 @@ class Scheduler
                 try {
                     $job->run();
                     $this->pushExecutedJob($job);
-                } catch (\Exception $e) {
+                } catch (Throwable $e) {
                     $this->pushFailedJob($job, $e);
                 }
             }
@@ -251,10 +251,10 @@ class Scheduler
      * Push a failed job.
      *
      * @param  Job  $job
-     * @param  Exception  $e
+     * @param  Throwable  $e
      * @return Job
      */
-    private function pushFailedJob(Job $job, Exception $e)
+    private function pushFailedJob(Job $job, Throwable $e)
     {
         $this->failedJobs[] = new FailedJob($job, $e);
 


### PR DESCRIPTION
Switched from using \Exception to using \Throwable, as it is more encompassing and can catch both Error and Exception types, improving error handling.