### PR TITLE
Add method to retrieve executionTime

### DIFF
--- a/src/GO/Job.php
+++ b/src/GO/Job.php
@@ -587,4 +587,16 @@ class Job
 
         return $this;
     }
+
+    /**
+     * @return Cron\CronExpression
+     */
+    public function getExecutionTime()
+    {
+        if (! $this->executionTime) {
+            return Cron\CronExpression::factory('* * * * *');
+        }
+
+        return $this->executionTime;
+    }
 }


### PR DESCRIPTION
For a project I wanted to implement a list / overview of all cronjobs as well as their next execution times, but had to discover that this information is not part of the public API of `Job`.

This PR adds a new `Job::getExecutionTime` method, which returns the underlying `CronExpression`.