### PR TITLE
use CronExpression::__construct instead of CronExpression::factory

### DIFF
--- a/src/GO/Traits/Interval.php
+++ b/src/GO/Traits/Interval.php
@@ -14,8 +14,8 @@ trait Interval
      */
     public function at($expression)
     {
-        $this->executionTime = CronExpression::factory($expression);
-
+        $this->executionTime = new CronExpression($expression);
+        
         return $this;
     }
 

--- a/src/GO/Traits/Interval.php
+++ b/src/GO/Traits/Interval.php
@@ -14,8 +14,7 @@ trait Interval
      */
     public function at($expression)
     {
-        $this->executionTime = CronExpression::factory($expression);
-
+        $this->executionTime = new CronExpression($expression);
         return $this;
     }
 


### PR DESCRIPTION
use CronExpression::__construct instead of CronExpression::factory, because CronExpression::factory deprecated since version 3.0.2.