### PR TITLE
Make nullable parameters explicit

### DIFF
--- a/src/GO/Job.php
+++ b/src/GO/Job.php
@@ -190,10 +190,10 @@ class Job
      * the job is due. Defaults to job creation time.
      * It also defaults the execution time if not previously defined.
      *
-     * @param  DateTime  $date
+     * @param  DateTime|null  $date
      * @return bool
      */
-    public function isDue(DateTime $date = null)
+    public function isDue(?DateTime $date = null)
     {
         // The execution time is being defaulted if not defined
         if (! $this->executionTime) {
@@ -253,11 +253,11 @@ class Job
      * being executed if the previous is still running.
      * The job id is used as a filename for the lock file.
      *
-     * @param  string    $tempDir          The directory path for the lock files
-     * @param  callable  $whenOverlapping  A callback to ignore job overlapping
+     * @param  string         $tempDir          The directory path for the lock files
+     * @param  callable|null  $whenOverlapping  A callback to ignore job overlapping
      * @return self
      */
-    public function onlyOne($tempDir = null, callable $whenOverlapping = null)
+    public function onlyOne($tempDir = null, ?callable $whenOverlapping = null)
     {
         if ($tempDir === null || ! is_dir($tempDir)) {
             $tempDir = $this->tempDir;

--- a/src/GO/Scheduler.php
+++ b/src/GO/Scheduler.php
@@ -160,10 +160,10 @@ class Scheduler
     /**
      * Run the scheduler.
      *
-     * @param  DateTime  $runTime  Optional, run at specific moment
+     * @param  DateTime|null  $runTime  Optional, run at specific moment
      * @return array  Executed jobs
      */
-    public function run(Datetime $runTime = null)
+    public function run(?Datetime $runTime = null)
     {
         $jobs = $this->getQueuedJobs();
 


### PR DESCRIPTION
100% backward compatible changes to avoid warning on PHP 8.4

https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated